### PR TITLE
promql: Provide an option to replace rate extrapolation funcs

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -16,6 +16,7 @@ package promql
 import (
 	"fmt"
 	"math"
+	"os"
 	"regexp"
 	"sort"
 	"strconv"
@@ -1304,6 +1305,21 @@ var functions = map[string]*Function{
 		ReturnType: ValueTypeVector,
 		Call:       funcYear,
 	},
+}
+
+func init() {
+	// REPLACE_RATE_FUNCS replaces the default rate extrapolation functions
+	// with xrate functions. This allows for a drop-in replacement and Grafana
+	// auto-completion, Prometheus tooling, Thanos, etc. should still work as expected.
+	if os.Getenv("REPLACE_RATE_FUNCS") == "1" {
+		functions["delta"] = functions["xdelta"]
+		functions["increase"] = functions["xincrease"]
+		functions["rate"] = functions["xrate"]
+		delete(functions, "xdelta")
+		delete(functions, "xincrease")
+		delete(functions, "xrate")
+		fmt.Println("Successfully replaced rate & friends with xrate & friends (and removed xrate & friends function keys).")
+	}
 }
 
 // getFunction returns a predefined Function object for the given name.


### PR DESCRIPTION
This change adds an option to replace the rate & friends functions outright with xrate & friends functions. It allows for a drop-in replacement to disable rate extrapolation without needing to change dashboards, recording rules, alerts, etc. This should also keep the ecosystem working: Grafana auto-complete, tooling, Thanos, etc.

I decided to use an env var since the kingpin flags aren't global and this should be easier to merge over time (otherwise we'd need to change main.go). I also figured it makes sense to remove the xrate keys if using this mode instead of having both sets.

Tested locally and ran queries too:
$ REPLACE_RATE_FUNCS=1 ./prometheus
Successfully replaced rate & friends with xrate & friends (and removed xrate & friends function keys).
level=info ts=2018-06-15T00:34:27.021727565Z caller=main.go:222 msg="Starting Prometheus"
...