### PR TITLE
promql: replace_rate_funcs: copy original name

### DIFF
--- a/promql/functions.go
+++ b/promql/functions.go
@@ -1315,6 +1315,9 @@ func init() {
 		functions["delta"] = functions["xdelta"]
 		functions["increase"] = functions["xincrease"]
 		functions["rate"] = functions["xrate"]
+		functions["delta"].Name = "delta"
+		functions["increase"].Name = "increase"
+		functions["rate"].Name = "rate"
 		delete(functions, "xdelta")
 		delete(functions, "xincrease")
 		delete(functions, "xrate")


### PR DESCRIPTION
Looking over this again -- when replacing the functions in the map, the Name field in the Function struct should also be updated from xrate & friends to rate & friends. Basic queries worked, so I'm not sure how this Name field is used. Regardless, it really should match.

I chose to do this instead of just swapping the Call field since it's possible that other fields in the Function struct between xrate/rate may differ over time. It seems safer to rename the functions without any other fields changing.